### PR TITLE
tail apache logs

### DIFF
--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -2,7 +2,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   namespace :bundler do
     desc "Automatically installed your bundled gems if a Gemfile exists"
     task :bundle_gems do
-      run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test,development; fi"
+      run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test,development --binstubs #{release_path}/bin; fi"
     end
     after "deploy:symlink_configs","bundler:bundle_gems"
   end

--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -1,8 +1,9 @@
 Capistrano::Configuration.instance(:must_exist).load do
   namespace :bundler do
     desc "Automatically installed your bundled gems if a Gemfile exists"
-    task :bundle_gems do
-      run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test,development --binstubs #{release_path}/bin; fi"
+    task :bundle_gems 
+      run "mkdir -p #{shared_path}/bundled_gems"
+      run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test,development --binstubs #{release_path}/bin --path #{shared_path}/bundled_gems; fi"
     end
     after "deploy:symlink_configs","bundler:bundle_gems"
   end

--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -1,7 +1,7 @@
 Capistrano::Configuration.instance(:must_exist).load do
   namespace :bundler do
     desc "Automatically installed your bundled gems if a Gemfile exists"
-    task :bundle_gems 
+    task :bundle_gems do
       run "mkdir -p #{shared_path}/bundled_gems"
       run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test,development --binstubs #{release_path}/bin --path #{shared_path}/bundled_gems; fi"
     end

--- a/lib/eycap/recipes/slice.rb
+++ b/lib/eycap/recipes/slice.rb
@@ -17,5 +17,13 @@ Capistrano::Configuration.instance(:must_exist).load do
         break if stream == :err    
       end
     end
+    desc "Tail the apache logs for your environment"
+    task :tail_apache_logs, :roles => [:app, :web] do
+      run "tail -f /var/log/apache2/#{application}.*.access.log" do |channel, stream, data|
+        puts # line break
+        puts "#{channel[:server]} -> #{data}"
+        break if stream == :err
+      end
+    end
   end
 end


### PR DESCRIPTION
Even though EY doesn't support apache some of us are running it there. This is a useful task for tailing apache log files like is possible with mongrel and application logs. I've found it useful for debugging.
