### PR TITLE
Fix db clone to local for postgres

### DIFF
--- a/lib/eycap/recipes/database.rb
+++ b/lib/eycap/recipes/database.rb
@@ -61,7 +61,11 @@ Capistrano::Configuration.instance(:must_exist).load do
       if ['mysql', 'mysql2'].include? development_info['adapter']
         run_str = "gunzip < /tmp/#{application}.sql.gz | mysql -u #{development_info['username']} --password='#{development_info['password']}' -h #{development_info['host']} #{development_info['database']}"
       else
-        run_str = "PGPASSWORD=#{development_info['password']} gunzip < /tmp/#{application}.sql.gz | psql -U #{development_info['username']} -h #{development_info['host']} #{development_info['database']}"
+        run_str  = ""
+        run_str += "PGPASSWORD=#{development_info['password']} " if development_info['password']
+        run_str += "gunzip < /tmp/#{application}.sql.gz | psql -U #{development_info['username']} "
+        run_str += "-h #{development_info['host']} "             if development_info['host']
+        run_str += development_info['database']
       end
       %x!#{run_str}!
       run "rm -f #{backup_file}.gz"


### PR DESCRIPTION
db:clone_to_local does not work when you do not have all all parameters defined. This is not the case for all set ups of Postgres. This should make things a little easier for those in similar shoes.
