### PR TITLE
added :except clause for non-nginx app servers

### DIFF
--- a/lib/eycap/recipes/nginx.rb
+++ b/lib/eycap/recipes/nginx.rb
@@ -2,37 +2,37 @@ Capistrano::Configuration.instance(:must_exist).load do
 
   namespace :nginx do 
     desc "Start Nginx on the app slices."
-    task :start, :roles => :app do
+    task :start, :roles => :app, :except => {:nginx => false} do
       sudo "nohup /etc/init.d/nginx start 2>&1 | cat"
     end
 
     desc "Restart the Nginx processes on the app slices."
-    task :restart , :roles => :app do
+    task :restart , :roles => :app, :except => {:nginx => false} do
       sudo "nohup /etc/init.d/nginx restart 2>&1 | cat"
     end
 
     desc "Stop the Nginx processes on the app slices."
-    task :stop , :roles => :app do
+    task :stop , :roles => :app, :except => {:nginx => false} do
       sudo "/etc/init.d/nginx stop"
     end
     
     desc "Reload the Nginx config on the app slices."
-    task :reload , :roles => :app do
+    task :reload , :roles => :app, :except => {:nginx => false} do
       sudo "/etc/init.d/nginx reload"
     end
 
     desc "Upgrade the Nginx processes on the app slices."
-    task :upgrade , :roles => :app do
+    task :upgrade , :roles => :app, :except => {:nginx => false} do
       sudo "/etc/init.d/nginx upgrade"
     end
 
     desc "Test the Nginx config on the app slices."
-    task :configtest , :roles => :app do
+    task :configtest , :roles => :app, :except => {:nginx => false} do
       sudo "/etc/init.d/nginx configtest"
     end
 
     desc "Tail the nginx error logs on the app slices"
-    task :tail_error, :roles => :app do
+    task :tail_error, :roles => :app, :except => {:nginx => false} do
       run "tail -f /var/log/engineyard/nginx/error.log" do |channel, stream, data|
         puts "#{channel[:server]}: #{data}" unless data =~ /^10\.[01]\.0/ # skips lb pull pages
         break if stream == :err    


### PR DESCRIPTION
This is useful when you have an app server that doesn't run nginx. In our case we have an app server dedicated to delayed_job and nothing else.
