### PR TITLE
symlink ey_bundler_binstubs to bin

### DIFF
--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -4,6 +4,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     task :bundle_gems do
       run "mkdir -p #{shared_path}/bundled_gems"
       run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test development --binstubs #{release_path}/bin --path #{shared_path}/bundled_gems; fi"
+      run "ln -nfs #{release_path}/bin #{release_path}/ey_bundler_binstubs"  
     end
     after "deploy:symlink_configs","bundler:bundle_gems"
   end


### PR DESCRIPTION
symlink current/ey_bunder_binstubs to current/bin for backwards compatibility reasons
