### PR TITLE
only perform the bundler.bundle_gems task on app servers that handle releases

### DIFF
--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -1,7 +1,7 @@
 Capistrano::Configuration.instance(:must_exist).load do
   namespace :bundler do
     desc "Automatically installed your bundled gems if a Gemfile exists"
-    task :bundle_gems do
+    task :bundle_gems, :roles => :app, :except => {:no_release => true} do
       run "mkdir -p #{shared_path}/bundled_gems"
       run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test development --binstubs #{release_path}/bin --path #{shared_path}/bundled_gems; fi"
       run "ln -nfs #{release_path}/bin #{release_path}/ey_bundler_binstubs"  


### PR DESCRIPTION
 This prevents redundant calls to this task.
