### PR TITLE
binstubs on NFS race condition fix

### DIFF
--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -4,7 +4,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     task :bundle_gems do
       run "mkdir -p #{shared_path}/bundled_gems"
       run "if [ -f #{release_path}/Gemfile ]; then cd #{release_path} && bundle install --without=test development --binstubs #{release_path}/bin --path #{shared_path}/bundled_gems; fi"
-      run "ln -nfs #{release_path}/bin #{release_path}/ey_bundler_binstubs"  
+			run "if [ ! -h #{release_path}/bin ]; then ln -nfs #{release_path}/bin #{release_path}/ey_bundler_binstubs;fi"
     end
     after "deploy:symlink_configs","bundler:bundle_gems"
   end


### PR DESCRIPTION
Alleviated the race condition that previously existed when making binstubs symlink on nfs-mounted /data
