### PR TITLE
Log more deploy commands

### DIFF
--- a/lib/eycap/recipes/deploy.rb
+++ b/lib/eycap/recipes/deploy.rb
@@ -3,7 +3,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   
   namespace :deploy do    
     # This is here to hook into the logger for deploy and deploy:long tasks
-    ["deploy", "deploy:long"].each do |tsk|
+    ["deploy", "deploy:long", "deploy:migrations", "deploy:migrate", "deploy:update_code"].each do |tsk|
       before(tsk) do
         Capistrano::EYLogger.setup( self, tsk )
         at_exit{ Capistrano::EYLogger.post_process if Capistrano::EYLogger.setup? }


### PR DESCRIPTION
Hi,

Considering these other deploy commands do make significant filesystem or db changes, it seems a good idea to add deploy:migrate, deploy:migrations, deploy:update_code to the list of actions that are logged to the shared directory.

Thanks,
Trevor
