### PR TITLE
hardcocded path to /engineyard/bin

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,13 +33,13 @@ To ensure your environments are ready to deploy, check on staging.
 
 This will determine if all requirements are met to deploy.  Sometimes if the default folders are not setup you may be able to repair by running:
 
-	$ cap staging deploy:setup
+    $ cap staging deploy:setup
 
 If you cannot get `deploy:check` to pass, please open a [new support ticket](https://support.cloud.engineyard.com/tickets/new) and let us know.
 
 Now you're ready to do a test deploy.
 
-Optionally, `cap deploy:cold` will run your migrations and start (instead of restart) your app server.  
+Optionally, `cap deploy:cold` will run your migrations and start (instead of restart) your app server.
 
     $ cap staging deploy:cold
 
@@ -57,15 +57,24 @@ For a list of all available commands, run:
 
     $ cap -T
 
-This will show you not only the default capistrano commands but also the ones you get by including the eycap gem.    
+This will show you not only the default capistrano commands but also the ones you get by including the eycap gem.
+
+## Custom binaries path
+
+In rare cases (`unicorn` / `sphinx`) it is required to set custom path for binaries when using
+development versions of scripts. It is as easy as:
+
+    $ set :engineyard_bin, "/engineyard/custom"
+
+The default is `/engineyard/bin` and is just fine in normal deployment.
 
 ## Pull Requests
- 
+
 If you'd like to contribute to the eycap gem please create a fork, then send a pull request and a member of the eycap team will review it.
 
 ## Issues
 
-When you run into a problem please check the [issues](/issues) to see if one has been reported.  If not, please report the issue and we'll get to work on fixing it. 
+When you run into a problem please check the [issues](/issues) to see if one has been reported.  If not, please report the issue and we'll get to work on fixing it.
 ## License
 
 Copyright (c) 2008-2012 Engine Yard

--- a/lib/eycap/recipes/backgroundrb.rb
+++ b/lib/eycap/recipes/backgroundrb.rb
@@ -3,9 +3,9 @@ Capistrano::Configuration.instance(:must_exist).load do
   namespace :bdrb do
     desc "After update_code you want to reindex"
     task :reindex, :roles => [:app], :only => {:backgroundrb => true} do
-      run "/engineyard/bin/searchd #{application} reindex"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/searchd #{application} reindex"
     end
-  
+
     desc "Start Backgroundrb"
     task :start, :roles => [:app], :only => {:backgroundrb => true} do
       sudo "/usr/bin/monit start all -g backgroundrb_#{application}"
@@ -17,7 +17,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     desc "Restart Backgroundrb"
     task :restart, :roles => [:app], :only => {:backgroundrb => true} do
       sudo "/usr/bin/monit restart all -g backgroundrb_#{application}"
-    end        
+    end
   end
 
 end

--- a/lib/eycap/recipes/sphinx.rb
+++ b/lib/eycap/recipes/sphinx.rb
@@ -3,12 +3,12 @@ Capistrano::Configuration.instance(:must_exist).load do
   namespace :sphinx do
     desc "After update_code you want to configure, then reindex"
     task :configure, :roles => [:app], :only => {:sphinx => true}, :except => {:no_release => true} do
-      run "/engineyard/bin/searchd #{application} configure"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/searchd #{application} configure"
     end
 
     desc "After configure you want to reindex"
     task :reindex, :roles => [:app], :only => {:sphinx => true} do
-      run "/engineyard/bin/searchd #{application} reindex"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/searchd #{application} reindex"
     end
 
     desc "Start Sphinx Searchd"
@@ -29,25 +29,25 @@ Capistrano::Configuration.instance(:must_exist).load do
     task :symlink, :roles => [:app], :only => {:sphinx => true}, :except => {:no_release => true} do
       run "if [ -d #{latest_release}/config/ultrasphinx ]; then mv #{latest_release}/config/ultrasphinx #{latest_release}/config/ultrasphinx.bak; fi"
       run "ln -nfs #{shared_path}/config/ultrasphinx #{latest_release}/config/ultrasphinx"
-    end  
+    end
   end
 
   namespace :acts_as_sphinx do
     desc "After update_code you to to reindex"
     task :reindex, :roles => [:app], :only => {:sphinx => true} do
-      run "/engineyard/bin/acts_as_sphinx_searchd #{application} reindex"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/acts_as_sphinx_searchd #{application} reindex"
     end
   end
 
   namespace :thinking_sphinx do
     desc "After update_code you want to configure, then reindex"
     task :configure, :roles => [:app], :only => {:sphinx => true}, :except => {:no_release => true} do
-      run "/engineyard/bin/thinking_sphinx_searchd #{application} configure #{rails_env}"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/thinking_sphinx_searchd #{application} configure #{rails_env}"
     end
 
     desc "After configure you want to reindex"
     task :reindex, :roles => [:app], :only => {:sphinx => true} do
-      run "/engineyard/bin/thinking_sphinx_searchd #{application} reindex #{rails_env}"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/thinking_sphinx_searchd #{application} reindex #{rails_env}"
     end
 
     task :symlink, :roles => [:app], :only => {:sphinx => true}, :except => {:no_release => true} do
@@ -60,17 +60,17 @@ Capistrano::Configuration.instance(:must_exist).load do
   namespace :ultrasphinx do
     desc "After update_code you want to configure, then reindex"
     task :configure, :roles => [:app], :only => {:sphinx => true}, :except => {:no_release => true} do
-      run "/engineyard/bin/ultrasphinx_searchd #{application} configure"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/ultrasphinx_searchd #{application} configure"
     end
 
     desc "After configure you want to reindex"
     task :reindex, :roles => [:app], :only => {:sphinx => true} do
-      run "/engineyard/bin/ultrasphinx_searchd #{application} reindex"
-    end   
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/ultrasphinx_searchd #{application} reindex"
+    end
 
     task :symlink, :roles => [:app], :only => {:sphinx => true}, :except => {:no_release => true} do
       run "if [ -d #{latest_release}/config/ultrasphinx ]; then mv #{latest_release}/config/ultrasphinx #{latest_release}/config/ultrasphinx.bak; fi"
       run "ln -nfs #{shared_path}/config/ultrasphinx #{latest_release}/config/ultrasphinx"
-    end    
+    end
   end
 end

--- a/lib/eycap/recipes/unicorn.rb
+++ b/lib/eycap/recipes/unicorn.rb
@@ -27,28 +27,28 @@ Capistrano::Configuration.instance(:must_exist).load do
     Reloads the unicorn works gracefully - Use deploy task for deploys
     DESC
     task :reload, :roles => [:app], :except => {:unicorn => false} do
-      run "/engineyard/bin/unicorn #{application} reload"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/unicorn #{application} reload"
     end
 
     desc <<-DESC
     Adds a Unicorn worker - Beware of causing your host to swap, this setting isn't permanent
     DESC
     task :aworker, :roles => [:app], :except => {:unicorn => false} do
-      run "/engineyard/bin/unicorn #{application} aworker"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/unicorn #{application} aworker"
     end
 
     desc <<-DESC
     Removes a unicorn worker (gracefully)
     DESC
     task :rworker, :roles => [:app], :except => {:unicorn => false} do
-      run "/engineyard/bin/unicorn #{application} rworker"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/unicorn #{application} rworker"
     end
 
     desc <<-DESC
     Deploys app gracefully with USR2 and unicorn.rb combo
     DESC
     task :deploy, :roles => [:app], :except => {:unicorn => false} do
-      run "/engineyard/bin/unicorn #{application} deploy"
+      run "#{fetch(:engineyard_bin, "/engineyard/bin")}/unicorn #{application} deploy"
     end
   end
 end


### PR DESCRIPTION
while working on new code for the scripts we use `/engineyard/custom` instead of `/engineyard/bin` for the new version of scripts (https://github.com/engineyard/eycap/blob/master/lib/eycap/recipes/unicorn.rb#L50), the simplest solution would be to extract a variable like: `engienyard_bin` which defaults to `/engineyard/bin` but can be set by user to any other location:

``` ruby
set :engineyard_bin, "/engineyard/custom"
```
