### PR TITLE
eycap v0.6.8 fails to detect rvm gem path with rvm-capistrano v1.4.3

### DIFF
--- a/lib/eycap.rb
+++ b/lib/eycap.rb
@@ -1,5 +1,6 @@
 require 'eycap/lib/ey_logger'
 require 'eycap/lib/ey_logger_hooks'
+require 'eycap/lib/rvm_helper'
 require 'eycap/recipes/apache'
 require 'eycap/recipes/backgroundrb'
 require 'eycap/recipes/bundler'

--- a/lib/eycap/lib/rvm_helper.rb
+++ b/lib/eycap/lib/rvm_helper.rb
@@ -1,0 +1,27 @@
+Capistrano::Configuration.instance(:must_exist).load do
+
+  def reformat_code(code)
+    code.split("\n").map(&:strip).join("; ")
+  end
+
+  # Allow parallel execution of rvm and non rvm commands
+  def run_rvm_or(command_rvm, command_else = "true")
+    parallel do |session|
+      command_else = reformat_code(command_else)
+      rvm_role = fetch(:rvm_require_role)
+      if Capistrano.const_defined?(:RvmMethods)
+        # command_with_shell is defined in RvmMethods so rvm/capistrano has to be required first
+        command_rvm  = command_with_shell(reformat_code(command_rvm), fetch(:rvm_shell))
+        if rvm_role # mixed
+          session.when "in?(:#{rvm_role})", command_rvm
+          session.else command_else
+        else # only rvm
+          session.else command_rvm
+        end
+      else # no rvm
+        session.else command_else
+      end
+    end
+  end
+
+end

--- a/lib/eycap/lib/rvm_helper.rb
+++ b/lib/eycap/lib/rvm_helper.rb
@@ -8,10 +8,10 @@ Capistrano::Configuration.instance(:must_exist).load do
   def run_rvm_or(command_rvm, command_else = "true")
     parallel do |session|
       command_else = reformat_code(command_else)
-      rvm_role = fetch(:rvm_require_role)
       if Capistrano.const_defined?(:RvmMethods)
         # command_with_shell is defined in RvmMethods so rvm/capistrano has to be required first
-        command_rvm  = command_with_shell(reformat_code(command_rvm), fetch(:rvm_shell))
+        command_rvm  = command_with_shell(reformat_code(command_rvm), fetch(:rvm_shell, "bash"))
+        rvm_role = fetch(:rvm_require_role, nil)
         if rvm_role # mixed
           session.when "in?(:#{rvm_role})", command_rvm
           session.else command_else

--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -5,32 +5,28 @@ set :bundle_without, "test development" unless exists?(:bundle_without)
   namespace :bundler do
     desc "Automatically installed your bundled gems if a Gemfile exists"
     task :bundle_gems, :roles => :app, :except => {:no_bundle => true} do
-      parallel do |session|
-        rvm_role = fetch(:rvm_require_role,"rvm")
-        if exists?(:rvm_shell)
-          session.when "in?(:#{rvm_role})", command_with_shell(<<-SHELL.split("\n").map(&:strip).join("; "), fetch(:rvm_shell))
-            if [ -f #{release_path}/Gemfile ]
-            then cd #{release_path} && bundle install --without=#{bundle_without} --system
-            fi
-          SHELL
-        end
-        session.else <<-SHELL.split("\n").map(&:strip).join("; ")
-          mkdir -p #{shared_path}/bundled_gems
-          if [ -f #{release_path}/Gemfile ]
-          then cd #{release_path} && bundle install --without=#{bundle_without} --binstubs #{release_path}/bin --path #{shared_path}/bundled_gems --quiet
-          fi
-          if [ ! -h #{release_path}/bin ]
-          then ln -nfs #{release_path}/bin #{release_path}/ey_bundler_binstubs
-          fi
-        SHELL
-      end
+      only_with_rvm = <<-SHELL
+        if [ -f #{release_path}/Gemfile ]
+        then cd #{release_path} && bundle install --without=#{bundle_without} --system
+        fi
+      SHELL
+      only_without_rvm = <<-SHELL
+        mkdir -p #{shared_path}/bundled_gems
+        if [ -f #{release_path}/Gemfile ]
+        then cd #{release_path} && bundle install --without=#{bundle_without} --binstubs #{release_path}/bin --path #{shared_path}/bundled_gems --quiet
+        fi
+        if [ ! -h #{release_path}/bin ]
+        then ln -nfs #{release_path}/bin #{release_path}/ey_bundler_binstubs
+        fi
+      SHELL
+      run_rvm_or only_with_rvm, only_without_rvm
     end
     task :bundle_config, :roles => :app, :only => {:no_bundle => true} do
-      <<-SHELL.split("\n").map(&:strip).join("; ")
+      run_rvm_or "true", <<-SHELL
         bundle config --local BIN /data/#{application}/releases/#{release_path}/bin
         bundle config --local PATH /data/#{application}/shared/bundled_gems
         bundle config --local DISABLE_SHARED_GEMS "1"
-        bundle config --local WITHOUT test:development 
+        bundle config --local WITHOUT test:development
       SHELL
     end
     after "deploy:symlink_configs","bundler:bundle_gems"

--- a/lib/eycap/recipes/bundler.rb
+++ b/lib/eycap/recipes/bundler.rb
@@ -21,7 +21,7 @@ set :bundle_without, "test development" unless exists?(:bundle_without)
       SHELL
       run_rvm_or only_with_rvm, only_without_rvm
     end
-    task :bundle_config, :roles => :app, :only => {:no_bundle => true} do
+    task :bundle_config, :roles => :app, :only => {:no_bundle => true}, :on_no_matching_servers => :continue do
       run_rvm_or "true", <<-SHELL
         bundle config --local BIN /data/#{application}/releases/#{release_path}/bin
         bundle config --local PATH /data/#{application}/shared/bundled_gems

--- a/lib/eycap/recipes/rvm.rb
+++ b/lib/eycap/recipes/rvm.rb
@@ -10,16 +10,10 @@ Capistrano::Configuration.instance(:must_exist).load do
       fi
     DESC
     task :create_wrappers, :roles => :app, :except => {:no_bundle => true} do
-      parallel do |session|
-        rvm_role = fetch(:rvm_require_role,"rvm")
-        if exists?(:rvm_shell)
-          session.when "in?(:#{rvm_role})", command_with_shell(<<-SHELL.split("\n").map(&:strip).join("; "), fetch(:rvm_shell))
-            rvm alias create #{application} #{fetch(:rvm_ruby_string,nil)}
-            rvm wrapper #{application} --no-links --all
-          SHELL
-        end
-        session.else "true" # minimal NOOP
-      end
+      run_rvm_or <<-SHELL
+        rvm alias create #{application} #{fetch(:rvm_ruby_string,nil)}
+        rvm wrapper #{application} --no-links --all
+      SHELL
     end
 
     after "bundler:bundle_gems","rvm:create_wrappers"


### PR DESCRIPTION
After upgrading to rvm-capistrano v1.4.3 in my Engine Yard Managed environment, my app's gems are now getting installed in `/data/app_name/shared/bundled_gems/ruby/1.9.1/gems` instead of in `/usr/local/rvm/gems/ruby-1.9.3-p429@app_name/gems/`.
